### PR TITLE
Add missing licenses

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -39,6 +39,47 @@ containing parts not covered by a compatible license, the licensors of
 this Program grant you additional permission to convey the resulting
 work.
 
+# SlashGaming Diablo II Modding API for C++98
+Copyright (C) 2018-2021  Mir Drualga
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining
+it with Diablo II (or a modified version of that game and its
+libraries), containing parts covered by the terms of Blizzard End User
+License Agreement, the licensors of this Program grant you additional
+permission to convey the resulting work. This additional permission is
+also extended to any combination of expansions, mods, and remasters of
+the game.
+
+If you modify this Program, or any covered work, by linking or combining
+it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+Glide, OpenGL, or Rave wrapper (or modified versions of those
+libraries), containing parts not covered by a compatible license, the
+licensors of this Program grant you additional permission to convey the
+resulting work.
+
+If you modify this Program, or any covered work, by linking or combining
+it with any library (or a modified version of that library) that links
+to Diablo II (or a modified version of that game and its libraries),
+containing parts not covered by a compatible license, the licensors of
+this Program grant you additional permission to convey the resulting
+work.
+
 # Mir Drualga Common For C
 Copyright (C) 2020  Mir Drualga
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -104,3 +104,23 @@ it with any program (or a modified version of that program and its
 libraries), containing parts covered by the terms of an incompatible
 license, the licensors of this Program grant you additional permission
 to convey the resulting work.
+
+# libunicows
+Copyright (c) 2001-2008 Vaclav Slavik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Adds licenses for "SGD2MAPI C++98" and "libunicows" to the LICENSE file.