### PR TITLE
Fix signature game version detection

### DIFF
--- a/SGD2MAPIc/SGD2MAPIc.dsp
+++ b/SGD2MAPIc/SGD2MAPIc.dsp
@@ -804,7 +804,35 @@ SOURCE=.\include\sgd2mapi.h
 # Begin Group "backend_c"
 
 # PROP Default_Filter ""
-# Begin Group "backend_game_address_table_h"
+# Begin Group "backend_d2se_c"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\src\c\backend\d2se\d2se_file_pe_signature.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\c\backend\d2se\d2se_file_pe_signature.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\c\backend\d2se\d2se_game_version.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\c\backend\d2se\d2se_game_version.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\c\backend\d2se\d2se_ini.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\c\backend\d2se\d2se_ini.h
+# End Source File
+# End Group
+# Begin Group "backend_game_address_table_c"
 
 # PROP Default_Filter ""
 # Begin Source File

--- a/SGD2MAPIc/src/c/backend/game_version/game_version_file_pe_signature.c
+++ b/SGD2MAPIc/src/c/backend/game_version/game_version_file_pe_signature.c
@@ -47,9 +47,8 @@
 
 #include <stdlib.h>
 
-#include <mdc/std/wchar.h>
-
 #include <mdc/error/exit_on_error.h>
+#include <mdc/std/wchar.h>
 #include <mdc/wchar_t/filew.h>
 #include "../../../../include/c/file/file_pe_signature.h"
 #include "../../../../include/c/game_executable.h"
@@ -400,8 +399,8 @@ static enum D2_GameVersion SearchTable(
    * and the key matches the type of file_pe_signature.
    */
   search_result = bsearch(
-      kSortedVersionTable,
       file_pe_signature,
+      kSortedVersionTable,
       kSortedVersionTableCount,
       sizeof(kSortedVersionTable[0]),
       &VersionTableEntry_CompareKeyAsVoid


### PR DESCRIPTION
These changes fix some issues with the game version detection. One fixes an incorrect ordering of parameters passed to `bsearch`. The second is update the VC6 project to include the new D2SE files.