### PR TITLE
Fix typo of D2common

### DIFF
--- a/SGD2MAPIcxx98/include/cxx98/game_function/d2common/d2common_get_global_belt_slot_position.hpp
+++ b/SGD2MAPIcxx98/include/cxx98/game_function/d2common/d2common_get_global_belt_slot_position.hpp
@@ -52,7 +52,7 @@
 #include "../../../dllexport_define.inc"
 
 namespace d2 {
-namespace d2commmon {
+namespace d2common {
 
 DLLEXPORT void GetGlobalBeltSlotPosition(
     unsigned int belt_record_index,
@@ -74,7 +74,7 @@ DLLEXPORT void GetGlobalBeltSlotPosition_1_07(
     uint32_t belt_slot_index
 );
 
-} // namespace d2commmon
+} // namespace d2common
 } // namespace d2
 
 #include "../../../dllexport_undefine.inc"

--- a/SGD2MAPIcxx98/include/cxx98/game_function/d2common/d2common_get_global_inventory_grid_layout.hpp
+++ b/SGD2MAPIcxx98/include/cxx98/game_function/d2common/d2common_get_global_inventory_grid_layout.hpp
@@ -52,7 +52,7 @@
 #include "../../../dllexport_define.inc"
 
 namespace d2 {
-namespace d2commmon {
+namespace d2common {
 
 DLLEXPORT void GetGlobalInventoryGridLayout(
     unsigned int inventory_record_index,
@@ -71,7 +71,7 @@ DLLEXPORT void GetGlobalInventoryGridLayout_1_07(
     GridLayout_1_00* out_grid_layout
 );
 
-} // namespace d2commmon
+} // namespace d2common
 } // namespace d2
 
 #include "../../../dllexport_undefine.inc"

--- a/SGD2MAPIcxx98/src/cxx98/game_function/d2common/d2common_get_global_belt_slot_position.cpp
+++ b/SGD2MAPIcxx98/src/cxx98/game_function/d2common/d2common_get_global_belt_slot_position.cpp
@@ -48,7 +48,7 @@
 #include <sgd2mapi.h>
 
 namespace d2 {
-namespace d2commmon {
+namespace d2common {
 
 void GetGlobalBeltSlotPosition(
     unsigned int belt_record_index,
@@ -90,5 +90,5 @@ void GetGlobalBeltSlotPosition_1_07(
   );
 }
 
-} // namespace d2commmon
+} // namespace d2common
 } // namespace d2

--- a/SGD2MAPIcxx98/src/cxx98/game_function/d2common/d2common_get_global_inventory_grid_layout.cpp
+++ b/SGD2MAPIcxx98/src/cxx98/game_function/d2common/d2common_get_global_inventory_grid_layout.cpp
@@ -48,7 +48,7 @@
 #include <sgd2mapi.h>
 
 namespace d2 {
-namespace d2commmon {
+namespace d2common {
 
 void GetGlobalInventoryGridLayout(
     unsigned int inventory_record_index,
@@ -84,5 +84,5 @@ void GetGlobalInventoryGridLayout_1_07(
   );
 }
 
-} // namespace d2commmon
+} // namespace d2common
 } // namespace d2


### PR DESCRIPTION
These changes fix a typo of d2common, being spelled d2commmon. This bug only affected the C++98 code.