### PR TITLE
Fix C89 CelContext Api typedef

### DIFF
--- a/SGD2MAPIc/include/c/game_struct/d2_cel_context.h
+++ b/SGD2MAPIc/include/c/game_struct/d2_cel_context.h
@@ -113,7 +113,7 @@ struct D2_CelContext_Api {
 typedef struct D2_CelContext D2_CelContext;
 typedef struct D2_CelContext_1_00 D2_CelContext_1_00;
 
-typedef struct D2_UnicodeChar_Api D2_UnicodeChar_Api;
+typedef struct D2_CelContext_Api D2_CelContext_Api;
 
 #endif /* SGD2MAPI_ENABLE_TYPEDEFS */
 


### PR DESCRIPTION
This change fixes an incorrectly defined C89 typedef for CelContext API.