### PR TITLE
Fix D2SE detection

### DIFF
--- a/SGD2MAPIc/src/c/file/file_pe_signature.c
+++ b/SGD2MAPIc/src/c/file/file_pe_signature.c
@@ -170,10 +170,12 @@ int Mapi_FilePeSignature_ReadFile(
 
   fread_count = fread(
       signature,
-      sizeof(signature[0]),
+      sizeof(signature->signature[0]),
       count,
       file
   );
+
+  signature->signature_count = count;
 
   if (fread_count < count) {
     Mdc_Error_ExitOnGeneralError(

--- a/SGD2MAPIc/src/c/game_executable.c
+++ b/SGD2MAPIc/src/c/game_executable.c
@@ -154,9 +154,8 @@ static void InitFileVersionInfo(void) {
     return;
   }
 
-  InitGameExecutable();
   file_version_info = Mapi_FileVersionInfo_InitFromPath(
-      game_executable_path
+      Mapi_GameExecutable_GetPath()
   );
 
   is_init = 1;

--- a/SGD2MAPIc/src/c/game_executable.c
+++ b/SGD2MAPIc/src/c/game_executable.c
@@ -92,6 +92,14 @@ static wchar_t* GetMemoryAllocGameExecutable(
     path_new_capacity *= 2;
   } while (*path_len >= path_capacity);
 
+  /* Shrink to fit. */
+  realloc_result = Mdc_realloc(path, (*path_len + 1) * sizeof(path[0]));
+  if (realloc_result == NULL) {
+    goto free_path;
+  }
+
+  path = realloc_result;
+
   return path;
 
 free_path:

--- a/SGD2MAPIc/src/c/game_executable.c
+++ b/SGD2MAPIc/src/c/game_executable.c
@@ -123,6 +123,7 @@ static void InitGameExecutable(void) {
   );
 
   if (game_executable_path_len < MAX_PATH) {
+    is_init = 1;
     return;
   }
 
@@ -153,23 +154,10 @@ static void InitFileVersionInfo(void) {
     return;
   }
 
+  InitGameExecutable();
   file_version_info = Mapi_FileVersionInfo_InitFromPath(
       game_executable_path
   );
-
-  is_init = 1;
-}
-
-static void InitStatic(void) {
-  static is_init = 0;
-
-  if (is_init) {
-    return;
-  }
-
-  InitGameExecutable();
-  InitIsD2se();
-  InitFileVersionInfo();
 
   is_init = 1;
 }
@@ -179,7 +167,7 @@ static void InitStatic(void) {
  */
 
 const wchar_t* Mapi_GameExecutable_GetPath(void) {
-  InitStatic();
+  InitGameExecutable();
 
   if (game_executable_path_len < MAX_PATH) {
     return game_executable_path;
@@ -189,7 +177,7 @@ const wchar_t* Mapi_GameExecutable_GetPath(void) {
 }
 
 int Mapi_GameExecutable_IsD2se(void) {
-  InitStatic();
+  InitIsD2se();
 
   return is_d2se;
 }
@@ -197,7 +185,7 @@ int Mapi_GameExecutable_IsD2se(void) {
 const wchar_t* Mapi_GameExecutable_QueryFileVersionInfoString(
     const wchar_t* sub_block
 ) {
-  InitStatic();
+  InitFileVersionInfo();
 
   return Mapi_FileVersionInfo_QueryString(
       &file_version_info,
@@ -209,13 +197,13 @@ const DWORD* Mapi_GameExecutable_QueryFileVersionInfoVar(
     const wchar_t* sub_block,
     size_t* count
 ) {
-  InitStatic();
+  InitFileVersionInfo();
 
   return Mapi_FileVersionInfo_QueryVar(&file_version_info, sub_block, count);
 }
 
 const VS_FIXEDFILEINFO* Mapi_GameExecutable_QueryFixedFileInfo(void) {
-  InitStatic();
+  InitFileVersionInfo();
 
   return Mapi_FileVersionInfo_QueryFixedFileInfo(&file_version_info);
 }


### PR DESCRIPTION
These changes fix the D2SE detection code by fixing related bugs. This fixes bugs that occur when calling the game executable functions. This also fixes bugs related to reading file PE signature.

Dynamically allocated game executable path (though unlikely to be necessary) now shrinks-to-fit on initialization.