### PR TITLE
Fix C++98 Cel Wrapper Get infinite recursion

### DIFF
--- a/SGD2MAPIcxx98/src/cxx98/game_struct/d2_cel/d2_cel_wrapper.cpp
+++ b/SGD2MAPIcxx98/src/cxx98/game_struct/d2_cel/d2_cel_wrapper.cpp
@@ -66,9 +66,7 @@ Cel* Cel_Wrapper::Get() {
 }
 
 const Cel* Cel_Wrapper::Get() const {
-  Cel_View view(*this);
-
-  return view.Get();
+  return reinterpret_cast<const Cel*>(this->cel_.v1_00);
 }
 
 int Cel_Wrapper::GetHeight() const {


### PR DESCRIPTION
These changes fix an infinite recursion bug when calling the C++98 Cel Wrapper type's Get function.