### PR TITLE
Fix missing DLLEXPORT on game address and patch

### DIFF
--- a/SGD2MAPIcxx98/include/cxx98/game_address.hpp
+++ b/SGD2MAPIcxx98/include/cxx98/game_address.hpp
@@ -52,9 +52,11 @@
 #include <sgd2mapi.h>
 #include "default_game_library.hpp"
 
+#include "../dllexport_define.inc"
+
 namespace mapi {
 
-class GameAddress {
+class DLLEXPORT GameAddress {
  public:
 
   /*
@@ -133,4 +135,5 @@ class GameAddress {
 
 } // namespace mapi
 
+#include "../dllexport_undefine.inc"
 #endif /* SGMAPI_CXX98_GAME_ADDRESS_HPP_ */

--- a/SGD2MAPIcxx98/include/cxx98/game_patch.hpp
+++ b/SGD2MAPIcxx98/include/cxx98/game_patch.hpp
@@ -54,9 +54,11 @@
 #include "game_address.hpp"
 #include "game_branch_type.hpp"
 
+#include "../dllexport_define.inc"
+
 namespace mapi {
 
-class GamePatch {
+class DLLEXPORT GamePatch {
 public:
   GamePatch();
 
@@ -165,4 +167,5 @@ private:
 
 } // namespace mapi
 
+#include "../dllexport_undefine.inc"
 #endif /* SGMAPI_CXX98_GAME_PATCH_HPP_ */


### PR DESCRIPTION
These changes fix the missing DLLEXPORT specifier on C++98 game address and game patch classes.