### PR TITLE
Fix DLLEXPORT name consistency

### DIFF
--- a/SGD2MAPIc/CMakeLists.txt
+++ b/SGD2MAPIc/CMakeLists.txt
@@ -386,8 +386,8 @@ add_dependencies(lib${PROJECT_NAME} libMDCc)
 # Output DLL
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE SGD2MAPIC_DLLEXPORT)
-target_compile_definitions(${PROJECT_NAME} INTERFACE SGD2MAPIC_DLLIMPORT)
+target_compile_definitions(${PROJECT_NAME} PRIVATE SGD2MAPI_C_DLLEXPORT)
+target_compile_definitions(${PROJECT_NAME} INTERFACE SGD2MAPI_C_DLLIMPORT)
 
 target_include_directories(${PROJECT_NAME} PUBLIC "include")
 

--- a/SGD2MAPIc/SGD2MAPIc.dsp
+++ b/SGD2MAPIc/SGD2MAPIc.dsp
@@ -98,7 +98,7 @@ LIB32=link.exe -lib
 # PROP Target_Dir ""
 CPP=cl.exe
 # ADD BASE CPP /nologo /MT /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /D "_MBCS" /D "_USRDLL" /D "EMPTYDLL_EXPORTS" /YX /FD /c
-# ADD CPP /nologo /MD /W3 /GX /O2 /I "../third_party/MDC/MDCc/include" /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "SGD2MAPIC_DLLEXPORT" /FD /c
+# ADD CPP /nologo /MD /W3 /GX /O2 /I "../third_party/MDC/MDCc/include" /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "SGD2MAPI_C_DLLEXPORT" /FD /c
 # SUBTRACT CPP /YX
 MTL=midl.exe
 # ADD BASE MTL /nologo /D "NDEBUG" /mktyplib203 /win32
@@ -129,7 +129,7 @@ LINK32=link.exe
 # PROP Target_Dir ""
 CPP=cl.exe
 # ADD BASE CPP /nologo /MTd /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_MBCS" /D "_USRDLL" /D "EMPTYDLL_EXPORTS" /YX /FD /GZ /c
-# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /I "../third_party/MDC/MDCc/include" /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "SGD2MAPIC_DLLEXPORT" /FD /GZ /c
+# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /I "../third_party/MDC/MDCc/include" /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "SGD2MAPI_C_DLLEXPORT" /FD /GZ /c
 # SUBTRACT CPP /YX
 MTL=midl.exe
 # ADD BASE MTL /nologo /D "_DEBUG" /mktyplib203 /win32

--- a/SGD2MAPIc/include/dllexport_define.inc
+++ b/SGD2MAPIc/include/dllexport_define.inc
@@ -43,9 +43,9 @@
  *  work.
  */
 
-#if defined(SGD2MAPIC_DLLEXPORT)
+#if defined(SGD2MAPI_C_DLLEXPORT)
   #define DLLEXPORT __declspec(dllexport)
-#elif defined(SGD2MAPIC_DLLIMPORT)
+#elif defined(SGD2MAPI_C_DLLIMPORT)
   #define DLLEXPORT __declspec(dllimport)
 #else
   #define DLLEXPORT

--- a/SGD2MAPIcpp98/CMakeLists.txt
+++ b/SGD2MAPIcpp98/CMakeLists.txt
@@ -394,8 +394,8 @@ add_dependencies(lib${PROJECT_NAME} libSGD2MAPIc libMDCcpp98 libMDCc)
 # Output DLL
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE SGD2MAPICPP98_DLLEXPORT)
-target_compile_definitions(${PROJECT_NAME} INTERFACE SGD2MAPICPP98_DLLIMPORT)
+target_compile_definitions(${PROJECT_NAME} PRIVATE SGD2MAPI_CPP98_DLLEXPORT)
+target_compile_definitions(${PROJECT_NAME} INTERFACE SGD2MAPI_CPP98_DLLIMPORT)
 
 target_include_directories(${PROJECT_NAME} PUBLIC "include")
 

--- a/SGD2MAPIcpp98/SGD2MAPIcpp98.dsp
+++ b/SGD2MAPIcpp98/SGD2MAPIcpp98.dsp
@@ -98,7 +98,7 @@ LIB32=link.exe -lib
 # PROP Target_Dir ""
 CPP=cl.exe
 # ADD BASE CPP /nologo /MT /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /D "_MBCS" /D "_USRDLL" /D "EMPTYDLL_EXPORTS" /YX /FD /c
-# ADD CPP /nologo /MD /W3 /GX /O2 /I "../third_party/MDC/MDCc/include" /I "../third_party/MDC/MDCcpp98/include" /I "../SGD2MAPIc/include" /D "WIN32" /D "NDEBUG" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "MDC_CPP98_DLLIMPORT" /D "SGD2MAPIC_DLLIMPORT" /D "SGD2MAPICPP98_DLLEXPORT" /FD /c
+# ADD CPP /nologo /MD /W3 /GX /O2 /I "../third_party/MDC/MDCc/include" /I "../third_party/MDC/MDCcpp98/include" /I "../SGD2MAPIc/include" /D "WIN32" /D "NDEBUG" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "MDC_CPP98_DLLIMPORT" /D "SGD2MAPI_C_DLLIMPORT" /D "SGD2MAPICPP98_DLLEXPORT" /FD /c
 # SUBTRACT CPP /YX
 MTL=midl.exe
 # ADD BASE MTL /nologo /D "NDEBUG" /mktyplib203 /win32
@@ -128,7 +128,7 @@ LINK32=link.exe
 # PROP Target_Dir ""
 CPP=cl.exe
 # ADD BASE CPP /nologo /MTd /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_MBCS" /D "_USRDLL" /D "EMPTYDLL_EXPORTS" /YX /FD /GZ /c
-# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /I "../third_party/MDC/MDCc/include" /I "../third_party/MDC/MDCcpp98/include" /I "../SGD2MAPIc/include" /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "MDC_CPP98_DLLIMPORT" /D "SGD2MAPIC_DLLIMPORT" /D "SGD2MAPICPP98_DLLEXPORT" /FD /GZ /c
+# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /I "../third_party/MDC/MDCc/include" /I "../third_party/MDC/MDCcpp98/include" /I "../SGD2MAPIc/include" /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "MDC_CPP98_DLLIMPORT" /D "SGD2MAPI_C_DLLIMPORT" /D "SGD2MAPICPP98_DLLEXPORT" /FD /GZ /c
 # SUBTRACT CPP /YX
 MTL=midl.exe
 # ADD BASE MTL /nologo /D "_DEBUG" /mktyplib203 /win32

--- a/SGD2MAPIcpp98/SGD2MAPIcpp98.dsp
+++ b/SGD2MAPIcpp98/SGD2MAPIcpp98.dsp
@@ -98,7 +98,7 @@ LIB32=link.exe -lib
 # PROP Target_Dir ""
 CPP=cl.exe
 # ADD BASE CPP /nologo /MT /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /D "_MBCS" /D "_USRDLL" /D "EMPTYDLL_EXPORTS" /YX /FD /c
-# ADD CPP /nologo /MD /W3 /GX /O2 /I "../third_party/MDC/MDCc/include" /I "../third_party/MDC/MDCcpp98/include" /I "../SGD2MAPIc/include" /D "WIN32" /D "NDEBUG" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "MDC_CPP98_DLLIMPORT" /D "SGD2MAPI_C_DLLIMPORT" /D "SGD2MAPICPP98_DLLEXPORT" /FD /c
+# ADD CPP /nologo /MD /W3 /GX /O2 /I "../third_party/MDC/MDCc/include" /I "../third_party/MDC/MDCcpp98/include" /I "../SGD2MAPIc/include" /D "WIN32" /D "NDEBUG" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "MDC_CPP98_DLLIMPORT" /D "SGD2MAPI_C_DLLIMPORT" /D "SGD2MAPI_CPP98_DLLEXPORT" /FD /c
 # SUBTRACT CPP /YX
 MTL=midl.exe
 # ADD BASE MTL /nologo /D "NDEBUG" /mktyplib203 /win32
@@ -128,7 +128,7 @@ LINK32=link.exe
 # PROP Target_Dir ""
 CPP=cl.exe
 # ADD BASE CPP /nologo /MTd /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_MBCS" /D "_USRDLL" /D "EMPTYDLL_EXPORTS" /YX /FD /GZ /c
-# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /I "../third_party/MDC/MDCc/include" /I "../third_party/MDC/MDCcpp98/include" /I "../SGD2MAPIc/include" /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "MDC_CPP98_DLLIMPORT" /D "SGD2MAPI_C_DLLIMPORT" /D "SGD2MAPICPP98_DLLEXPORT" /FD /GZ /c
+# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /I "../third_party/MDC/MDCc/include" /I "../third_party/MDC/MDCcpp98/include" /I "../SGD2MAPIc/include" /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /D "_UNICODE" /D "UNICODE" /D "MDC_C_DLLIMPORT" /D "MDC_CPP98_DLLIMPORT" /D "SGD2MAPI_C_DLLIMPORT" /D "SGD2MAPI_CPP98_DLLEXPORT" /FD /GZ /c
 # SUBTRACT CPP /YX
 MTL=midl.exe
 # ADD BASE MTL /nologo /D "_DEBUG" /mktyplib203 /win32

--- a/SGD2MAPIcpp98/include/dllexport_define.inc
+++ b/SGD2MAPIcpp98/include/dllexport_define.inc
@@ -43,9 +43,9 @@
  *  work.
  */
 
-#if defined(SGD2MAPICPP98_DLLEXPORT)
+#if defined(SGD2MAPI_CPP98_DLLEXPORT)
   #define DLLEXPORT __declspec(dllexport)
-#elif defined(SGD2MAPICPP98_DLLIMPORT)
+#elif defined(SGD2MAPI_CPP98_DLLIMPORT)
   #define DLLEXPORT __declspec(dllimport)
 #else
   #define DLLEXPORT


### PR DESCRIPTION
These changes rename the DLLEXPORT macros to give the name some consistency with MDC's naming.