### PR TITLE
Fix file PE signature missing first 4 bytes

### DIFF
--- a/SGD2MAPIc/src/sgd2mapi98/file/file_pe_signature.c
+++ b/SGD2MAPIc/src/sgd2mapi98/file/file_pe_signature.c
@@ -169,7 +169,7 @@ int Mapi_FilePeSignature_ReadFile(
   }
 
   fread_count = fread(
-      signature,
+      signature->signature,
       sizeof(signature->signature[0]),
       count,
       file


### PR DESCRIPTION
These changes fix an issue that caused version detection via file PE signature to fail.