### PR TITLE
Add C++98 default game library GetHandle function

### DIFF
--- a/SGD2MAPIcpp98/include/sgd2mapi98/default_game_library.hpp
+++ b/SGD2MAPIcpp98/include/sgd2mapi98/default_game_library.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2MAPI_CPP98_DEFAULT_GAME_LIBRARY_HPP_
 #define SGD2MAPI_CPP98_DEFAULT_GAME_LIBRARY_HPP_
 
+#include <windows.h>
+
 #include <mdc/std/wchar.h>
 
 #include "../dllexport_define.inc"
@@ -73,6 +75,10 @@ enum DefaultLibrary {
 typedef default_library::DefaultLibrary DefaultLibrary;
 
 namespace default_library {
+
+DLLEXPORT HMODULE GetHandle(
+    DefaultLibrary library,
+    bool is_allow_redirect_to_game_exe);
 
 DLLEXPORT const wchar_t* GetPathWithRedirect(DefaultLibrary library);
 

--- a/SGD2MAPIcpp98/src/sgd2mapi98/default_game_library.cpp
+++ b/SGD2MAPIcpp98/src/sgd2mapi98/default_game_library.cpp
@@ -50,6 +50,14 @@
 namespace d2 {
 namespace default_library {
 
+HMODULE GetHandle(
+    DefaultLibrary library,
+    bool is_allow_redirect_to_game_exe) {
+  return D2_DefaultLibrary_GetHandle(
+      static_cast<D2_DefaultLibrary>(library),
+      is_allow_redirect_to_game_exe);
+}
+
 const wchar_t* GetPathWithRedirect(DefaultLibrary library) {
   return D2_DefaultLibrary_GetPathWithRedirect(
       static_cast<D2_DefaultLibrary>(library)


### PR DESCRIPTION
Was added to C89 API, missing for C++98.