### PR TITLE
Remove game library from VC6 project

### DIFF
--- a/SGD2MAPIc/SGD2MAPIc.dsp
+++ b/SGD2MAPIc/SGD2MAPIc.dsp
@@ -1213,14 +1213,6 @@ SOURCE=.\src\sgd2mapi98\backend\game_address_table.c
 
 SOURCE=.\src\sgd2mapi98\backend\game_address_table.h
 # End Source File
-# Begin Source File
-
-SOURCE=.\src\sgd2mapi98\backend\game_library.cpp
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\sgd2mapi98\backend\game_library.h
-# End Source File
 # End Group
 # Begin Group "file_c"
 


### PR DESCRIPTION
These changes fix VC6 not compiling by removing files that no longer exist from the project.